### PR TITLE
Rename `get` to `list` for `Metrics`

### DIFF
--- a/openapi/paths/metrics/getMetrics.yaml
+++ b/openapi/paths/metrics/getMetrics.yaml
@@ -1,4 +1,4 @@
-summary: Get Metrics
+summary: List Metrics
 description: |
   Retrieve monitored metrics for connected services.
 
@@ -7,7 +7,7 @@ description: |
 
   The output is based on Prometheus "Time Series Data Model":
   [Prometheus Time Series Data Model](https://prometheus.io/docs/concepts/data_model)
-operationId: getMetrics
+operationId: listMetrics
 responses:
   "200":
     content:

--- a/openapi/paths/metrics/index.yaml
+++ b/openapi/paths/metrics/index.yaml
@@ -1,2 +1,2 @@
 get:
-  $ref: getMetrics.yaml
+  $ref: listMetrics.yaml


### PR DESCRIPTION
This PR updates the wording to prefer `list` over `get` as is the standard for this endpoint type for the codebase