### PR TITLE
fix: update schema references to use lowercase filenames

### DIFF
--- a/openapi/components/schemas/_index.yaml
+++ b/openapi/components/schemas/_index.yaml
@@ -1,56 +1,56 @@
 x-metadata:
   $ref: x-metadata.yaml
 Activity:
-  $ref: Activity.yaml
+  $ref: activity.yaml
 Collections:
-  $ref: Collections.yaml
+  $ref: collections.yaml
 Comments:
-  $ref: Comments.yaml
+  $ref: comments.yaml
 Dashboards:
-  $ref: Dashboards.yaml
+  $ref: dashboards.yaml
 Diff:
-  $ref: Diff.yaml
+  $ref: diff.yaml
 Extensions:
-  $ref: Extensions.yaml
+  $ref: extensions.yaml
 Fields:
-  $ref: Fields.yaml
+  $ref: fields.yaml
 Files:
-  $ref: Files.yaml
+  $ref: files.yaml
 Flows:
-  $ref: Flows.yaml
+  $ref: flows.yaml
 Folders:
-  $ref: Folders.yaml
+  $ref: folders.yaml
 Items:
-  $ref: Items.yaml
+  $ref: items.yaml
 Notifications:
-  $ref: Notifications.yaml
+  $ref: notifications.yaml
 Operations:
-  $ref: Operations.yaml
+  $ref: operations.yaml
 Panels:
-  $ref: Panels.yaml
+  $ref: panels.yaml
 Permissions:
-  $ref: Permissions.yaml
+  $ref: permissions.yaml
 Policies:
-  $ref: Policies.yaml
+  $ref: policies.yaml
 Presets:
-  $ref: Presets.yaml
+  $ref: presets.yaml
 Query:
-  $ref: Query.yaml
+  $ref: query.yaml
 Relations:
-  $ref: Relations.yaml
+  $ref: relations.yaml
 Revisions:
-  $ref: Revisions.yaml
+  $ref: revisions.yaml
 Roles:
-  $ref: Roles.yaml
+  $ref: roles.yaml
 Schema:
-  $ref: Schema.yaml
+  $ref: schema.yaml
 Settings:
-  $ref: Settings.yaml
+  $ref: settings.yaml
 Shares:
-  $ref: Shares.yaml
+  $ref: shares.yaml
 Translations:
-  $ref: Translations.yaml
+  $ref: translations.yaml
 Users:
-  $ref: Users.yaml
+  $ref: users.yaml
 Versions:
-  $ref: Versions.yaml
+  $ref: versions.yaml

--- a/openapi/components/schemas/activity.yaml
+++ b/openapi/components/schemas/activity.yaml
@@ -17,7 +17,7 @@ properties:
     description: The user who performed this action. Many-to-one to users.
     type: string
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
     nullable: true
   timestamp:
     description: When the action happened.
@@ -38,7 +38,7 @@ properties:
     description: Collection identifier in which the item resides.
     oneOf:
       - type: string
-      - $ref: Collections.yaml
+      - $ref: collections.yaml
   item:
     description: Unique identifier for the item the action applied to. This is always a string, even for integer primary keys.
     example: '328'
@@ -58,5 +58,5 @@ properties:
     type: array
     items:
       oneOf:
-        - $ref: Revisions.yaml
+        - $ref: revisions.yaml
 x-collection: directus_activity

--- a/openapi/components/schemas/collections.yaml
+++ b/openapi/components/schemas/collections.yaml
@@ -64,7 +64,7 @@ properties:
     description: The name of the parent collection.
     type: string
     oneOf:
-      - $ref: Collections.yaml
+      - $ref: collections.yaml
   collapse:
     nullable: false
     description: What is the default behavior of this collection or "folder" collection when it has nested collections. One of `open`, `closed`, `locked`.

--- a/openapi/components/schemas/comments.yaml
+++ b/openapi/components/schemas/comments.yaml
@@ -32,11 +32,11 @@ properties:
     example: 12e62fd0-29c7-4fd3-b3d3-c7a39933e8af
     type: string
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
   user_updated:
     description: The user who last updated the comment. Many-to-one to users.
     example: 12e62fd0-29c7-4fd3-b3d3-c7a39933e8af
     type: string
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
 x-collection: directus_comments

--- a/openapi/components/schemas/dashboards.yaml
+++ b/openapi/components/schemas/dashboards.yaml
@@ -28,7 +28,7 @@ properties:
     type: string
     format: relation
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
   color:
     description: Accent color for the dashboard.
     example: #6644FF
@@ -39,5 +39,5 @@ properties:
     example: 22640672-eef0-4ee9-ab04-591f3afb2883
     type: string
     oneOf:
-      - $ref: Panels.yaml
+      - $ref: panels.yaml
 x-collection: directus_shares

--- a/openapi/components/schemas/fields.yaml
+++ b/openapi/components/schemas/fields.yaml
@@ -66,7 +66,7 @@ properties:
     nullable: true
     type: integer
     oneOf:
-      - $ref: Fields.yaml
+      - $ref: fields.yaml
   # validation:
   #   nullable: true
   validation_message:

--- a/openapi/components/schemas/files.yaml
+++ b/openapi/components/schemas/files.yaml
@@ -30,14 +30,14 @@ properties:
     example: null
     type: string
     oneOf:
-      - $ref: Folders.yaml
+      - $ref: folders.yaml
     nullable: true
   uploaded_by:
     description: Who uploaded the file.
     example: 63716273-0f29-4648-8a2a-2af2948f6f78
     oneOf:
       - type: string
-      - $ref: Users.yaml
+      - $ref: users.yaml
   created_on:
     description: When the file was created.
     example: 2019-12-03T00:10:15+00:00
@@ -47,7 +47,7 @@ properties:
     type: string
     format: uuid
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
     nullable: true
   modified_on:
     nullable: false

--- a/openapi/components/schemas/flows.yaml
+++ b/openapi/components/schemas/flows.yaml
@@ -49,7 +49,7 @@ properties:
     oneOf:
       - type: string
       - format: uuid
-      - $ref: Operations.yaml
+      - $ref: operations.yaml
   date_created:
     description: Timestamp in ISO8601 when the flow was created.
     type: string
@@ -61,7 +61,7 @@ properties:
     example: 63716273-0f29-4648-8a2a-2af2948f6f78
     oneOf:
       - type: string
-      - $ref: Users.yaml
+      - $ref: users.yaml
   operations:
     nullable: true
     type: array
@@ -69,5 +69,5 @@ properties:
       oneOf:
         - type: string
           format: uuid
-        - $ref: Operations.yaml
+        - $ref: operations.yaml
 x-collection: directus_flows

--- a/openapi/components/schemas/folders.yaml
+++ b/openapi/components/schemas/folders.yaml
@@ -21,6 +21,6 @@ properties:
       }
     type: string
     oneOf:
-      - $ref: Folders.yaml
+      - $ref: folders.yaml
     nullable: true
 x-collection: directus_folders

--- a/openapi/components/schemas/notifications.yaml
+++ b/openapi/components/schemas/notifications.yaml
@@ -18,13 +18,13 @@ properties:
     example: 3EE34828-B43C-4FB2-A721-5151579B08EA
     oneOf:
       - type: string
-      - $ref: Users.yaml
+      - $ref: users.yaml
   sender:
     description: User that sent the notification, if any.
     example: 497a495e-5529-4e46-8feb-2f35e9b85601
     oneOf:
       - type: string
-      - $ref: Users.yaml
+      - $ref: users.yaml
   subject:
     description: Subject line of the message.
     example: inbox

--- a/openapi/components/schemas/operations.yaml
+++ b/openapi/components/schemas/operations.yaml
@@ -35,19 +35,19 @@ properties:
     example: 63716273-0f29-4648-8a2a-2af2948f6f78
     oneOf:
       - type: string
-      - $ref: Operations.yaml
+      - $ref: operations.yaml
   reject:
     description: The operation triggered when the current operation fails (or `otherwise` logic of a condition operation).
     example: 63716273-0f29-4648-8a2a-2af2948f6f78
     oneOf:
       - type: string
-      - $ref: Operations.yaml
+      - $ref: operations.yaml
   flow:
     nullable: false
     type: string
     format: uuid
     oneOf:
-      - $ref: Flows.yaml
+      - $ref: flows.yaml
   date_created:
     description: Timestamp in ISO8601 when the operation was created.
     type: string
@@ -59,5 +59,5 @@ properties:
     example: 63716273-0f29-4648-8a2a-2af2948f6f78
     oneOf:
       - type: string
-      - $ref: Users.yaml
+      - $ref: users.yaml
 x-collection: directus_operations

--- a/openapi/components/schemas/panels.yaml
+++ b/openapi/components/schemas/panels.yaml
@@ -10,7 +10,7 @@ properties:
     example: a79bd1b2-beb2-49fc-8a26-0b3eec0e269
     oneOf:
       - type: string
-      - $ref: Dashboards.yaml
+      - $ref: dashboards.yaml
   name:
     description: Name of the panel.
     example: 30-day sales
@@ -66,5 +66,5 @@ properties:
     example: fd066644-c8e5-499d-947b-fe6c6e1a1473
     oneOf:
       - type: string
-      - $ref: Users.yaml
+      - $ref: users.yaml
 x-collection: directus_panels

--- a/openapi/components/schemas/permissions.yaml
+++ b/openapi/components/schemas/permissions.yaml
@@ -41,5 +41,5 @@ properties:
     format: uuid
     type: string
     oneOf:
-      - $ref: Policies.yaml
+      - $ref: policies.yaml
 x-collection: directus_permissions

--- a/openapi/components/schemas/policies.yaml
+++ b/openapi/components/schemas/policies.yaml
@@ -40,19 +40,19 @@ properties:
     oneOf:
       - type: array
       - format: many-to-many
-      - $ref: Users.yaml
+      - $ref: users.yaml
   roles:
     description: The roles this policy is assigned to. It expects and returns data from the directus_access collection. Many-to-many to roles via access.
     example: ["8b4474c0-288d-4bb8-b62e-8330646bb6aa"]
     oneOf:
       - type: array
       - format: many-to-many
-      - $ref: Roles.yaml
+      - $ref: roles.yaml
   permissions:
     description: The permissions assigned to this policy. One-to-many to permissions.
     example: ["5c74c86f-cab0-4b14-a3c4-cd4f2363e826"]
     oneOf:
       - type: array
       - format: one-to-many
-      - $ref: Permissions.yaml
+      - $ref: permissions.yaml
 x-collection: directus_policies

--- a/openapi/components/schemas/presets.yaml
+++ b/openapi/components/schemas/presets.yaml
@@ -14,20 +14,20 @@ properties:
     nullable: true
     type: string
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
   role:
     description: The unique identifier of a role in the platform. If `user` is null, this will be used to apply the collection preset or bookmark for all users in the role.
     example: 50419801-0f30-8644-2b3c-9bc2d980d0a0
     nullable: true
     type: string
     oneOf:
-      - $ref: Roles.yaml
+      - $ref: roles.yaml
   collection:
     description: What collection this collection preset is used for.
     example: articles
     oneOf:
       - type: string
-      - $ref: Collections.yaml
+      - $ref: collections.yaml
   search:
     description: Search query.
     type: string

--- a/openapi/components/schemas/revisions.yaml
+++ b/openapi/components/schemas/revisions.yaml
@@ -9,13 +9,13 @@ properties:
     example: 2
     type: integer
     oneOf:
-      - $ref: Activity.yaml
+      - $ref: activity.yaml
   collection:
     description: Collection of the updated item.
     example: articles
     type: string
     oneOf:
-      - $ref: Collections.yaml
+      - $ref: collections.yaml
   item:
     description: Primary key of updated item.
     example: '168'
@@ -45,5 +45,5 @@ properties:
     example: draft
     type: string
     oneOf:
-      - $ref: Versions.yaml
+      - $ref: versions.yaml
 x-collection: directus_revisions

--- a/openapi/components/schemas/roles.yaml
+++ b/openapi/components/schemas/roles.yaml
@@ -24,7 +24,7 @@ properties:
     type: string
     format: uuid
     oneOf:
-      - $ref: Roles.yaml
+      - $ref: roles.yaml
   children:
     nullable: true
     description: Nested child roles that inherit this roles permissions. One-to-many to roles. One-to-many to roles.
@@ -32,7 +32,7 @@ properties:
     format: uuid
     items:
       oneOf:
-        - $ref: Roles.yaml
+        - $ref: roles.yaml
   policies:
     nullable: true
     description: The policies in this role. Many-to-many to roles.
@@ -40,7 +40,7 @@ properties:
     format: uuid
     items:
       oneOf:
-        - $ref: Roles.yaml
+        - $ref: roles.yaml
   users:
     nullable: true
     description: The users in this role. One-to-many to users.
@@ -48,5 +48,5 @@ properties:
     format: uuid
     items:
       oneOf:
-        - $ref: Users.yaml
+        - $ref: users.yaml
 x-collection: directus_roles

--- a/openapi/components/schemas/schema.yaml
+++ b/openapi/components/schemas/schema.yaml
@@ -10,12 +10,12 @@ properties:
   collections:
     type: array
     items:
-      $ref: Collections.yaml
+      $ref: collections.yaml
   fields:
     type: array
     items:
-      $ref: Fields.yaml
+      $ref: fields.yaml
   relations:
     type: array
     items:
-      $ref: Relations.yaml
+      $ref: relations.yaml

--- a/openapi/components/schemas/settings.yaml
+++ b/openapi/components/schemas/settings.yaml
@@ -25,21 +25,21 @@ properties:
     example: null
     nullable: true
     oneOf:
-      - $ref: Files.yaml
+      - $ref: files.yaml
   public_foreground:
     description: The foreground of the project. Many-to-one to files.
     type: string
     example: null
     nullable: true
     oneOf:
-      - $ref: Files.yaml
+      - $ref: files.yaml
   public_background:
     description: The background of the project. Many-to-one to files.
     type: object
     example: null
     nullable: true
     oneOf:
-      - $ref: Files.yaml
+      - $ref: files.yaml
   public_note:
     description: Note rendered on the public pages of the app.
     type: string
@@ -156,7 +156,7 @@ properties:
     description: Favicon for the Data Studio. Many-to-one to files.
     type: string
     oneOf:
-      - $ref: Files.yaml
+      - $ref: files.yaml
   default_appearance:
     description: One of auto, light, dark.
     nullable: false

--- a/openapi/components/schemas/shares.yaml
+++ b/openapi/components/schemas/shares.yaml
@@ -14,7 +14,7 @@ properties:
     example: articles
     type: string
     oneOf:
-      - $ref: Collections.yaml
+      - $ref: collections.yaml
   item:
     description: Primary key of the item that's shared.
     example: '1'
@@ -25,7 +25,7 @@ properties:
     type: string
     format: uuid
     oneOf:
-      - $ref: Shares.yaml
+      - $ref: shares.yaml
   password:
     description: Optional password that's required to view this shared item.
     example: '**********'
@@ -37,7 +37,7 @@ properties:
     type: string
     format: uuid
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
   date_created:
     description: When the share was created.
     example: 2023-01-25T19:16:49.009Z

--- a/openapi/components/schemas/users.yaml
+++ b/openapi/components/schemas/users.yaml
@@ -48,7 +48,7 @@ properties:
     example: null
     type: string
     oneOf:
-      - $ref: Files.yaml
+      - $ref: files.yaml
     nullable: true
   language:
     description: The user's language used in Directus. Language the Data Studio is rendered in. See our Crowdin page for all available languages and translations.
@@ -74,7 +74,7 @@ properties:
     example: 2f24211d-d928-469a-aea3-3c8f53d4e426
     type: string
     oneOf:
-      - $ref: Roles.yaml
+      - $ref: roles.yaml
   token:
     description: Static token for the user.
     type: string
@@ -85,7 +85,7 @@ properties:
     example: 2f24211d-d928-469a-aea3-3c8f53d4e426
     type: string
     oneOf:
-      - $ref: Policies.yaml
+      - $ref: policies.yaml
   last_access:
     description: When this user used the API last.
     example: '2020-05-31T14:32:37Z'

--- a/openapi/components/schemas/versions.yaml
+++ b/openapi/components/schemas/versions.yaml
@@ -17,13 +17,13 @@ properties:
     example: articles
     type: string
     oneOf:
-      - $ref: Collections.yaml
+      - $ref: collections.yaml
   item:
     description: The item the Content Version is created on. Many-to-one to items.
     example: '168'
     type: string
     oneOf:
-      - $ref: Items.yaml
+      - $ref: items.yaml
   hash:
     nullable: true
     type: string
@@ -44,13 +44,13 @@ properties:
     example: 63716273-0f29-4648-8a2a-2af2948f6f78
     type: string
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
   user_updated:
     description: User that updated the Content Version. Many-to-one to users.
     example: 63716273-0f29-4648-8a2a-2af2948f6f78
     type: string
     oneOf:
-      - $ref: Users.yaml
+      - $ref: users.yaml
   delta:
     description: The current changes compared to the main version of the item.
     type: object

--- a/openapi/paths/activity/_id/getActivity.yaml
+++ b/openapi/paths/activity/_id/getActivity.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Activity.yaml
+              $ref: ../../../components/schemas/activity.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/activity/getActivities.yaml
+++ b/openapi/paths/activity/getActivities.yaml
@@ -19,7 +19,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Activity.yaml
+                $ref: ../../components/schemas/activity.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
     description: Successful request

--- a/openapi/paths/collections/_id/getCollection.yaml
+++ b/openapi/paths/collections/_id/getCollection.yaml
@@ -17,7 +17,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Collections.yaml
+              $ref: ../../../components/schemas/collections.yaml
     description: Successful request
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/collections/_id/updateCollection.yaml
+++ b/openapi/paths/collections/_id/updateCollection.yaml
@@ -98,7 +98,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Collections.yaml
+              $ref: ../../../components/schemas/collections.yaml
     description: Successful request
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/collections/createCollection.yaml
+++ b/openapi/paths/collections/createCollection.yaml
@@ -97,7 +97,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../components/schemas/Collections.yaml
+              $ref: ../../components/schemas/collections.yaml
     description: Successful request
   '401':
     $ref: ../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/comments/_id/getComment.yaml
+++ b/openapi/paths/comments/_id/getComment.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Comments.yaml
+              $ref: ../../../components/schemas/comments.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/comments/_id/updateComment.yaml
+++ b/openapi/paths/comments/_id/updateComment.yaml
@@ -9,7 +9,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Comments.yaml
+        - $ref: ../../../components/schemas/comments.yaml
 responses:
   '200':
     content:
@@ -18,7 +18,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Activity.yaml
+              $ref: ../../../components/schemas/activity.yaml
     description: Successful request
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/comments/createComments.yaml
+++ b/openapi/paths/comments/createComments.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Comments.yaml
+              $ref: ../../components/schemas/comments.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Comments.yaml
+                $ref: ../../components/schemas/comments.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/comments/getComments.yaml
+++ b/openapi/paths/comments/getComments.yaml
@@ -20,7 +20,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Comments.yaml
+                $ref: ../../components/schemas/comments.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
     description: Successful request

--- a/openapi/paths/comments/updateComments.yaml
+++ b/openapi/paths/comments/updateComments.yaml
@@ -17,7 +17,7 @@ requestBody:
         type: object
         properties:
           data:
-            $ref: ../../components/schemas/Comments.yaml
+            $ref: ../../components/schemas/comments.yaml
           keys:
             type: array
             items:
@@ -33,7 +33,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Comments.yaml
+                $ref: ../../components/schemas/comments.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/dashboards/_id/getDashboard.yaml
+++ b/openapi/paths/dashboards/_id/getDashboard.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Dashboards.yaml
+              $ref: ../../../components/schemas/dashboards.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/dashboards/_id/updateDashboard.yaml
+++ b/openapi/paths/dashboards/_id/updateDashboard.yaml
@@ -15,7 +15,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Dashboards.yaml
+        - $ref: ../../../components/schemas/dashboards.yaml
 responses:
   '200':
     description: Successful request
@@ -25,7 +25,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Dashboards.yaml
+              $ref: ../../../components/schemas/dashboards.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/dashboards/createDashboards.yaml
+++ b/openapi/paths/dashboards/createDashboards.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Dashboards.yaml
+              $ref: ../../components/schemas/dashboards.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Dashboards.yaml
+                $ref: ../../components/schemas/dashboards.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/dashboards/getDashboards.yaml
+++ b/openapi/paths/dashboards/getDashboards.yaml
@@ -22,7 +22,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Dashboards.yaml
+                $ref: ../../components/schemas/dashboards.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/dashboards/updateDashboards.yaml
+++ b/openapi/paths/dashboards/updateDashboards.yaml
@@ -20,7 +20,7 @@ requestBody:
           - keys
         properties:
           data:
-            $ref: ../../components/schemas/Dashboards.yaml
+            $ref: ../../components/schemas/dashboards.yaml
           keys:
             type: array
             items:
@@ -36,7 +36,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Dashboards.yaml
+                $ref: ../../components/schemas/dashboards.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/extensions/_bundle/_name/updateExtensionBundle.yaml
+++ b/openapi/paths/extensions/_bundle/_name/updateExtensionBundle.yaml
@@ -35,7 +35,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Extensions.yaml
+              $ref: ../../../../components/schemas/extensions.yaml
     description: Successful request
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/extensions/_name/updateExtensions.yaml
+++ b/openapi/paths/extensions/_name/updateExtensions.yaml
@@ -30,7 +30,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Extensions.yaml
+              $ref: ../../../components/schemas/extensions.yaml
     description: Successful request
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/extensions/listExtensions.yaml
+++ b/openapi/paths/extensions/listExtensions.yaml
@@ -11,7 +11,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Extensions.yaml
+                $ref: ../../components/schemas/extensions.yaml
     description: Successful request
   '401':
     $ref: ../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/fields/_collection/_id/getCollectionField.yaml
+++ b/openapi/paths/fields/_collection/_id/getCollectionField.yaml
@@ -10,7 +10,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Fields.yaml
+              $ref: ../../../../components/schemas/fields.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/fields/_collection/_id/updateField.yaml
+++ b/openapi/paths/fields/_collection/_id/updateField.yaml
@@ -190,7 +190,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Fields.yaml
+              $ref: ../../../../components/schemas/fields.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/fields/_collection/createField.yaml
+++ b/openapi/paths/fields/_collection/createField.yaml
@@ -194,7 +194,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Fields.yaml
+              $ref: ../../../components/schemas/fields.yaml
     description: Successful request
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/fields/_collection/getCollectionFields.yaml
+++ b/openapi/paths/fields/_collection/getCollectionFields.yaml
@@ -20,7 +20,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../../components/schemas/Fields.yaml
+                $ref: ../../../components/schemas/fields.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/fields/getFields.yaml
+++ b/openapi/paths/fields/getFields.yaml
@@ -15,7 +15,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Fields.yaml
+                $ref: ../../components/schemas/fields.yaml
   '401':
     $ref: ../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/files/_id/getFile.yaml
+++ b/openapi/paths/files/_id/getFile.yaml
@@ -17,7 +17,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Files.yaml
+              $ref: ../../../components/schemas/files.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 x-codeSamples:

--- a/openapi/paths/files/_id/updateFile.yaml
+++ b/openapi/paths/files/_id/updateFile.yaml
@@ -22,7 +22,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Items.yaml
+        - $ref: ../../../components/schemas/items.yaml
 responses:
   '200':
     description: Successful request
@@ -32,7 +32,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Files.yaml
+              $ref: ../../../components/schemas/files.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 x-codeSamples:

--- a/openapi/paths/files/getFiles.yaml
+++ b/openapi/paths/files/getFiles.yaml
@@ -23,7 +23,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Files.yaml
+                $ref: ../../components/schemas/files.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/files/import/importFile.yaml
+++ b/openapi/paths/files/import/importFile.yaml
@@ -13,7 +13,7 @@ requestBody:
             type: string
             description: The URL to download the file from.
           data:
-            $ref: ../../../components/schemas/Files.yaml
+            $ref: ../../../components/schemas/files.yaml
 responses:
   '200':
     description: Successful request
@@ -23,7 +23,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Files.yaml
+              $ref: ../../../components/schemas/files.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 security: []

--- a/openapi/paths/files/updateFiles.yaml
+++ b/openapi/paths/files/updateFiles.yaml
@@ -41,7 +41,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Files.yaml
+                $ref: ../../components/schemas/files.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/files/uploadFile.yaml
+++ b/openapi/paths/files/uploadFile.yaml
@@ -6,7 +6,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../components/schemas/Files.yaml
+        - $ref: ../../components/schemas/files.yaml
 responses:
   '200':
     description: Successful request
@@ -16,7 +16,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../components/schemas/Files.yaml
+              $ref: ../../components/schemas/files.yaml
   '401':
     $ref: ../../components/responses.yaml#/UnauthorizedError
 security: []

--- a/openapi/paths/flows/_id/getFlow.yaml
+++ b/openapi/paths/flows/_id/getFlow.yaml
@@ -10,7 +10,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Flows.yaml
+              $ref: ../../../components/schemas/flows.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/flows/_id/updateFlow.yaml
+++ b/openapi/paths/flows/_id/updateFlow.yaml
@@ -10,7 +10,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Flows.yaml
+        - $ref: ../../../components/schemas/flows.yaml
 responses:
   '200':
     description: Successful request
@@ -20,7 +20,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Flows.yaml
+              $ref: ../../../components/schemas/flows.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/flows/createFlows.yaml
+++ b/openapi/paths/flows/createFlows.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Flows.yaml
+              $ref: ../../components/schemas/flows.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Flows.yaml
+                $ref: ../../components/schemas/flows.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/flows/getFlows.yaml
+++ b/openapi/paths/flows/getFlows.yaml
@@ -20,7 +20,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Flows.yaml
+                $ref: ../../components/schemas/flows.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/flows/updateFlows.yaml
+++ b/openapi/paths/flows/updateFlows.yaml
@@ -23,7 +23,7 @@ requestBody:
         properties:
           data:
             anyOf:
-              - $ref: ../../components/schemas/Flows.yaml
+              - $ref: ../../components/schemas/flows.yaml
           keys:
             type: array
             items:
@@ -39,7 +39,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Flows.yaml
+                $ref: ../../components/schemas/flows.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/folders/_id/getFolder.yaml
+++ b/openapi/paths/folders/_id/getFolder.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Folders.yaml
+              $ref: ../../../components/schemas/folders.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/folders/_id/updateFolder.yaml
+++ b/openapi/paths/folders/_id/updateFolder.yaml
@@ -28,7 +28,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Folders.yaml
+              $ref: ../../../components/schemas/folders.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/folders/createFolders.yaml
+++ b/openapi/paths/folders/createFolders.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Folders.yaml
+              $ref: ../../components/schemas/folders.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Folders.yaml
+                $ref: ../../components/schemas/folders.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/folders/getFolders.yaml
+++ b/openapi/paths/folders/getFolders.yaml
@@ -20,7 +20,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Folders.yaml
+                $ref: ../../components/schemas/folders.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/folders/updateFolders.yaml
+++ b/openapi/paths/folders/updateFolders.yaml
@@ -52,7 +52,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Folders.yaml
+                $ref: ../../components/schemas/folders.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/items/_collection/_id/getCollectionItem.yaml
+++ b/openapi/paths/items/_collection/_id/getCollectionItem.yaml
@@ -16,7 +16,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Items.yaml
+              $ref: ../../../../components/schemas/items.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/items/_collection/_id/updateItem.yaml
+++ b/openapi/paths/items/_collection/_id/updateItem.yaml
@@ -16,7 +16,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../../components/schemas/Items.yaml
+        - $ref: ../../../../components/schemas/items.yaml
 responses:
   '200':
     description: Successful request
@@ -26,7 +26,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Items.yaml
+              $ref: ../../../../components/schemas/items.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/items/_collection/createItems.yaml
+++ b/openapi/paths/items/_collection/createItems.yaml
@@ -20,7 +20,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../../components/schemas/Items.yaml
+              $ref: ../../../components/schemas/items.yaml
 responses:
   '200':
     description: Successful request
@@ -32,7 +32,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../../components/schemas/Items.yaml
+                $ref: ../../../components/schemas/items.yaml
             meta:
               $ref: ../../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/items/_collection/getCollectionItems.yaml
+++ b/openapi/paths/items/_collection/getCollectionItems.yaml
@@ -26,7 +26,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../../components/schemas/Items.yaml
+                $ref: ../../../components/schemas/items.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/items/_collection/singleton/getSingleton.yaml
+++ b/openapi/paths/items/_collection/singleton/getSingleton.yaml
@@ -18,7 +18,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Items.yaml
+              $ref: ../../../../components/schemas/items.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/items/_collection/singleton/updateSingleton.yaml
+++ b/openapi/paths/items/_collection/singleton/updateSingleton.yaml
@@ -13,7 +13,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../../components/schemas/Items.yaml
+        - $ref: ../../../../components/schemas/items.yaml
 responses:
   '200':
     description: Successful request
@@ -23,7 +23,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Items.yaml
+              $ref: ../../../../components/schemas/items.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/items/_collection/updateItems.yaml
+++ b/openapi/paths/items/_collection/updateItems.yaml
@@ -21,7 +21,7 @@ requestBody:
           - keys
         properties:
           data:
-            $ref: ../../../components/schemas/Items.yaml
+            $ref: ../../../components/schemas/items.yaml
           keys:
             type: array
             items:
@@ -37,7 +37,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../../components/schemas/Items.yaml
+                $ref: ../../../components/schemas/items.yaml
             meta:
               $ref: ../../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/notifications/_id/getNotification.yaml
+++ b/openapi/paths/notifications/_id/getNotification.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Notifications.yaml
+              $ref: ../../../components/schemas/notifications.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/notifications/_id/updateNotification.yaml
+++ b/openapi/paths/notifications/_id/updateNotification.yaml
@@ -15,7 +15,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-          - $ref: ../../../components/schemas/Notifications.yaml
+          - $ref: ../../../components/schemas/notifications.yaml
 responses:
   '200':
     description: Successful request
@@ -25,7 +25,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Notifications.yaml
+              $ref: ../../../components/schemas/notifications.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/notifications/createNotifications.yaml
+++ b/openapi/paths/notifications/createNotifications.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Notifications.yaml
+              $ref: ../../components/schemas/notifications.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Notifications.yaml
+                $ref: ../../components/schemas/notifications.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/notifications/getNotifications.yaml
+++ b/openapi/paths/notifications/getNotifications.yaml
@@ -22,7 +22,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Notifications.yaml
+                $ref: ../../components/schemas/notifications.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/notifications/updateNotifications.yaml
+++ b/openapi/paths/notifications/updateNotifications.yaml
@@ -20,7 +20,7 @@ requestBody:
           - keys
         properties:
           data:
-            $ref: ../../components/schemas/Notifications.yaml
+            $ref: ../../components/schemas/notifications.yaml
           keys:
             type: array
             items:
@@ -36,7 +36,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Notifications.yaml
+                $ref: ../../components/schemas/notifications.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/operations/_id/getOperation.yaml
+++ b/openapi/paths/operations/_id/getOperation.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Operations.yaml
+              $ref: ../../../components/schemas/operations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/operations/_id/updateOperation.yaml
+++ b/openapi/paths/operations/_id/updateOperation.yaml
@@ -10,7 +10,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Operations.yaml
+        - $ref: ../../../components/schemas/operations.yaml
 responses:
   '200':
     description: Successful request
@@ -20,7 +20,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Operations.yaml
+              $ref: ../../../components/schemas/operations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/operations/createOperations.yaml
+++ b/openapi/paths/operations/createOperations.yaml
@@ -19,7 +19,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Operations.yaml
+              $ref: ../../components/schemas/operations.yaml
 responses:
   '200':
     description: Successful request
@@ -31,7 +31,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Operations.yaml
+                $ref: ../../components/schemas/operations.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/operations/getOperations.yaml
+++ b/openapi/paths/operations/getOperations.yaml
@@ -21,7 +21,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Operations.yaml
+                $ref: ../../components/schemas/operations.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/operations/updateOperations.yaml
+++ b/openapi/paths/operations/updateOperations.yaml
@@ -23,7 +23,7 @@ requestBody:
         properties:
           data:
             anyOf:
-            - $ref: ../../components/schemas/Operations.yaml
+            - $ref: ../../components/schemas/operations.yaml
           keys:
             type: array
             items:
@@ -39,7 +39,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Operations.yaml
+                $ref: ../../components/schemas/operations.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/panels/_id/getPanel.yaml
+++ b/openapi/paths/panels/_id/getPanel.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Panels.yaml
+              $ref: ../../../components/schemas/panels.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/panels/_id/updatePanel.yaml
+++ b/openapi/paths/panels/_id/updatePanel.yaml
@@ -15,7 +15,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Panels.yaml
+        - $ref: ../../../components/schemas/panels.yaml
 responses:
   '200':
     description: Successful request
@@ -25,7 +25,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Panels.yaml
+              $ref: ../../../components/schemas/panels.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/panels/createPanels.yaml
+++ b/openapi/paths/panels/createPanels.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Panels.yaml
+              $ref: ../../components/schemas/panels.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Panels.yaml
+                $ref: ../../components/schemas/panels.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/panels/getPanels.yaml
+++ b/openapi/paths/panels/getPanels.yaml
@@ -22,7 +22,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Panels.yaml
+                $ref: ../../components/schemas/panels.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/panels/updatePanels.yaml
+++ b/openapi/paths/panels/updatePanels.yaml
@@ -20,7 +20,7 @@ requestBody:
           - data
         properties:
           data:
-            $ref: ../../components/schemas/Panels.yaml
+            $ref: ../../components/schemas/panels.yaml
           keys:
             type: array
             items:
@@ -36,7 +36,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Panels.yaml
+                $ref: ../../components/schemas/panels.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/permissions/_id/getPermission.yaml
+++ b/openapi/paths/permissions/_id/getPermission.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Permissions.yaml
+              $ref: ../../../components/schemas/permissions.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/permissions/_id/updatePermission.yaml
+++ b/openapi/paths/permissions/_id/updatePermission.yaml
@@ -83,7 +83,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Permissions.yaml
+              $ref: ../../../components/schemas/permissions.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/permissions/createPermissions.yaml
+++ b/openapi/paths/permissions/createPermissions.yaml
@@ -22,7 +22,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Permissions.yaml
+              $ref: ../../components/schemas/permissions.yaml
 responses:
   '200':
     description: Successful request
@@ -34,7 +34,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Permissions.yaml
+                $ref: ../../components/schemas/permissions.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/permissions/getPermissions.yaml
+++ b/openapi/paths/permissions/getPermissions.yaml
@@ -21,7 +21,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Permissions.yaml
+                $ref: ../../components/schemas/permissions.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/permissions/updatePermissions.yaml
+++ b/openapi/paths/permissions/updatePermissions.yaml
@@ -22,7 +22,7 @@ requestBody:
           - keys
         properties:
           data:
-            $ref: ../../components/schemas/Permissions.yaml
+            $ref: ../../components/schemas/permissions.yaml
           keys:
             type: array
             items:
@@ -38,7 +38,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Permissions.yaml
+                $ref: ../../components/schemas/permissions.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/policies/_id/getPolicy.yaml
+++ b/openapi/paths/policies/_id/getPolicy.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Policies.yaml
+              $ref: ../../../components/schemas/policies.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/policies/_id/updatePolicy.yaml
+++ b/openapi/paths/policies/_id/updatePolicy.yaml
@@ -15,7 +15,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Policies.yaml
+        - $ref: ../../../components/schemas/policies.yaml
 responses:
   '200':
     description: Successful request
@@ -25,7 +25,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Policies.yaml
+              $ref: ../../../components/schemas/policies.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/policies/createPolicies.yaml
+++ b/openapi/paths/policies/createPolicies.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Policies.yaml
+              $ref: ../../components/schemas/policies.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Policies.yaml
+                $ref: ../../components/schemas/policies.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/policies/getPolicies.yaml
+++ b/openapi/paths/policies/getPolicies.yaml
@@ -22,7 +22,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Policies.yaml
+                $ref: ../../components/schemas/policies.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/policies/updatePolicies.yaml
+++ b/openapi/paths/policies/updatePolicies.yaml
@@ -19,7 +19,7 @@ requestBody:
           - data
         properties:
           data:
-            $ref: ../../components/schemas/Policies.yaml
+            $ref: ../../components/schemas/policies.yaml
           keys:
             type: array
             items:
@@ -35,7 +35,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Policies.yaml
+                $ref: ../../components/schemas/policies.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/presets/_id/getPreset.yaml
+++ b/openapi/paths/presets/_id/getPreset.yaml
@@ -17,7 +17,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Presets.yaml
+              $ref: ../../../components/schemas/presets.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 x-codeSamples:

--- a/openapi/paths/presets/_id/updatePreset.yaml
+++ b/openapi/paths/presets/_id/updatePreset.yaml
@@ -72,7 +72,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Presets.yaml
+              $ref: ../../../components/schemas/presets.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 x-codeSamples:

--- a/openapi/paths/presets/createPresets.yaml
+++ b/openapi/paths/presets/createPresets.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Presets.yaml
+              $ref: ../../components/schemas/presets.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Presets.yaml
+                $ref: ../../components/schemas/presets.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/presets/getPresets.yaml
+++ b/openapi/paths/presets/getPresets.yaml
@@ -24,7 +24,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Presets.yaml
+                $ref: ../../components/schemas/presets.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/presets/updatePresets.yaml
+++ b/openapi/paths/presets/updatePresets.yaml
@@ -89,7 +89,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Presets.yaml
+                $ref: ../../components/schemas/presets.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/relations/_collection/getRelationByCollection.yaml
+++ b/openapi/paths/relations/_collection/getRelationByCollection.yaml
@@ -19,7 +19,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../../components/schemas/Relations.yaml
+                $ref: ../../../components/schemas/relations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/relations/_id/getRelation.yaml
+++ b/openapi/paths/relations/_id/getRelation.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Relations.yaml
+              $ref: ../../../components/schemas/relations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/relations/_id/updateRelation.yaml
+++ b/openapi/paths/relations/_id/updateRelation.yaml
@@ -38,7 +38,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Relations.yaml
+              $ref: ../../../components/schemas/relations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/relations/createRelation.yaml
+++ b/openapi/paths/relations/createRelation.yaml
@@ -40,7 +40,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../components/schemas/Relations.yaml
+              $ref: ../../components/schemas/relations.yaml
   '401':
     $ref: ../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/revisions/_id/getRevision.yaml
+++ b/openapi/paths/revisions/_id/getRevision.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Revisions.yaml
+              $ref: ../../../components/schemas/revisions.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/revisions/getRevisions.yaml
+++ b/openapi/paths/revisions/getRevisions.yaml
@@ -24,7 +24,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Revisions.yaml
+                $ref: ../../components/schemas/revisions.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/roles/_id/getRole.yaml
+++ b/openapi/paths/roles/_id/getRole.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Roles.yaml
+              $ref: ../../../components/schemas/roles.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/roles/_id/updateRole.yaml
+++ b/openapi/paths/roles/_id/updateRole.yaml
@@ -41,7 +41,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Roles.yaml
+              $ref: ../../../components/schemas/roles.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/roles/createRoles.yaml
+++ b/openapi/paths/roles/createRoles.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Roles.yaml
+              $ref: ../../components/schemas/roles.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Roles.yaml
+                $ref: ../../components/schemas/roles.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/roles/getRoles.yaml
+++ b/openapi/paths/roles/getRoles.yaml
@@ -21,7 +21,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Roles.yaml
+                $ref: ../../components/schemas/roles.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/roles/updateRoles.yaml
+++ b/openapi/paths/roles/updateRoles.yaml
@@ -61,7 +61,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Roles.yaml
+                $ref: ../../components/schemas/roles.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/schema/apply/schemaApply.yaml
+++ b/openapi/paths/schema/apply/schemaApply.yaml
@@ -9,7 +9,7 @@ requestBody:
     application/json:
       schema:
         type: object
-        $ref: ../../../components/schemas/Diff.yaml
+        $ref: ../../../components/schemas/diff.yaml
     multipart/form-data:
       schema:
         type: object

--- a/openapi/paths/schema/diff/schemaDiff.yaml
+++ b/openapi/paths/schema/diff/schemaDiff.yaml
@@ -19,7 +19,7 @@ requestBody:
     application/json:
       schema:
         type: object
-        $ref: ../../../components/schemas/Schema.yaml
+        $ref: ../../../components/schemas/schema.yaml
     multipart/form-data:
       schema:
         type: object
@@ -34,7 +34,7 @@ responses:
       application/json:
         schema:
           type: object
-          $ref: ../../../components/schemas/Diff.yaml
+          $ref: ../../../components/schemas/diff.yaml
   '204':
     description: No schema difference.
   '403':

--- a/openapi/paths/schema/snapshot/schemaSnapshot.yaml
+++ b/openapi/paths/schema/snapshot/schemaSnapshot.yaml
@@ -11,7 +11,7 @@ responses:
       application/json:
         schema:
           type: object
-          $ref: ../../../components/schemas/Schema.yaml
+          $ref: ../../../components/schemas/schema.yaml
       text/yaml:
         schema:
           type: string

--- a/openapi/paths/server/info/serverInfo.yaml
+++ b/openapi/paths/server/info/serverInfo.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Settings.yaml
+              $ref: ../../../components/schemas/settings.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/settings/getSettings.yaml
+++ b/openapi/paths/settings/getSettings.yaml
@@ -15,7 +15,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../components/schemas/Settings.yaml
+              $ref: ../../components/schemas/settings.yaml
   '401':
     $ref: ../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/settings/updateSettings.yaml
+++ b/openapi/paths/settings/updateSettings.yaml
@@ -9,7 +9,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../components/schemas/Settings.yaml
+        - $ref: ../../components/schemas/settings.yaml
 responses:
   '200':
     description: Successful request
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../components/schemas/Settings.yaml
+              $ref: ../../components/schemas/settings.yaml
   '401':
     $ref: ../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/shares/_id/getShare.yaml
+++ b/openapi/paths/shares/_id/getShare.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Shares.yaml
+              $ref: ../../../components/schemas/shares.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/shares/_id/updateShare.yaml
+++ b/openapi/paths/shares/_id/updateShare.yaml
@@ -15,7 +15,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Shares.yaml
+        - $ref: ../../../components/schemas/shares.yaml
 responses:
   '200':
     description: Successful request
@@ -25,7 +25,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Shares.yaml
+              $ref: ../../../components/schemas/shares.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/shares/_share/getPublicShareInfo.yaml
+++ b/openapi/paths/shares/_share/getPublicShareInfo.yaml
@@ -17,7 +17,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Shares.yaml
+              $ref: ../../../components/schemas/shares.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/shares/createShares.yaml
+++ b/openapi/paths/shares/createShares.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Shares.yaml
+              $ref: ../../components/schemas/shares.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Shares.yaml
+                $ref: ../../components/schemas/shares.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/shares/getShares.yaml
+++ b/openapi/paths/shares/getShares.yaml
@@ -22,7 +22,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Shares.yaml
+                $ref: ../../components/schemas/shares.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/shares/info/_id/getShareInfo.yaml
+++ b/openapi/paths/shares/info/_id/getShareInfo.yaml
@@ -17,7 +17,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Shares.yaml
+              $ref: ../../../../components/schemas/shares.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/shares/updateShares.yaml
+++ b/openapi/paths/shares/updateShares.yaml
@@ -20,7 +20,7 @@ requestBody:
           - data
         properties:
           data:
-            $ref: ../../components/schemas/Shares.yaml
+            $ref: ../../components/schemas/shares.yaml
           keys:
             type: array
             items:
@@ -36,7 +36,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Shares.yaml
+                $ref: ../../components/schemas/shares.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/translations/_id/getTranslation.yaml
+++ b/openapi/paths/translations/_id/getTranslation.yaml
@@ -19,7 +19,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Translations.yaml
+              $ref: ../../../components/schemas/translations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/translations/_id/updateTranslation.yaml
+++ b/openapi/paths/translations/_id/updateTranslation.yaml
@@ -15,7 +15,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Translations.yaml
+        - $ref: ../../../components/schemas/translations.yaml
 responses:
   '200':
     description: Successful request
@@ -25,7 +25,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Translations.yaml
+              $ref: ../../../components/schemas/translations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/translations/createTranslations.yaml
+++ b/openapi/paths/translations/createTranslations.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Translations.yaml
+              $ref: ../../components/schemas/translations.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Translations.yaml
+                $ref: ../../components/schemas/translations.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/translations/getTranslations.yaml
+++ b/openapi/paths/translations/getTranslations.yaml
@@ -22,7 +22,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Translations.yaml
+                $ref: ../../components/schemas/translations.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/translations/singular/createTranslation.yaml
+++ b/openapi/paths/translations/singular/createTranslation.yaml
@@ -10,7 +10,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Translations.yaml
+        - $ref: ../../../components/schemas/translations.yaml
 responses:
   '200':
     description: Successful request
@@ -20,7 +20,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Translations.yaml
+              $ref: ../../../components/schemas/translations.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/translations/updateTranslations.yaml
+++ b/openapi/paths/translations/updateTranslations.yaml
@@ -17,7 +17,7 @@ requestBody:
         type: object
         properties:
           data:
-            $ref: ../../components/schemas/Translations.yaml
+            $ref: ../../components/schemas/translations.yaml
           keys:
             type: array
             items:
@@ -33,7 +33,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Translations.yaml
+                $ref: ../../components/schemas/translations.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/users/_id/getUser.yaml
+++ b/openapi/paths/users/_id/getUser.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Users.yaml
+              $ref: ../../../components/schemas/users.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/users/_id/updateUser.yaml
+++ b/openapi/paths/users/_id/updateUser.yaml
@@ -9,7 +9,7 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: ../../../components/schemas/Users.yaml
+        $ref: ../../../components/schemas/users.yaml
 responses:
   '200':
     content:

--- a/openapi/paths/users/createUsers.yaml
+++ b/openapi/paths/users/createUsers.yaml
@@ -20,7 +20,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Users.yaml
+              $ref: ../../components/schemas/users.yaml
 responses:
   '200':
     description: Successful request
@@ -32,7 +32,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Users.yaml
+                $ref: ../../components/schemas/users.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/users/getUsers.yaml
+++ b/openapi/paths/users/getUsers.yaml
@@ -20,7 +20,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Users.yaml
+                $ref: ../../components/schemas/users.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/users/me/getMe.yaml
+++ b/openapi/paths/users/me/getMe.yaml
@@ -13,7 +13,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Users.yaml
+              $ref: ../../../components/schemas/users.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/users/me/updateMe.yaml
+++ b/openapi/paths/users/me/updateMe.yaml
@@ -13,7 +13,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Users.yaml
+              $ref: ../../../components/schemas/users.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/users/updateUsers.yaml
+++ b/openapi/paths/users/updateUsers.yaml
@@ -19,7 +19,7 @@ requestBody:
         type: object
         properties:
           data:
-            $ref: ../../components/schemas/Users.yaml
+            $ref: ../../components/schemas/users.yaml
           keys:
             type: array
             items:
@@ -35,7 +35,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Users.yaml
+                $ref: ../../components/schemas/users.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/utils/export/_collection/export.yaml
+++ b/openapi/paths/utils/export/_collection/export.yaml
@@ -21,9 +21,9 @@ requestBody:
               - xml
               - json
           query:
-            $ref: ../../../../components/schemas/Query.yaml
+            $ref: ../../../../components/schemas/query.yaml
           file:
-            $ref: ../../../../components/schemas/Files.yaml
+            $ref: ../../../../components/schemas/files.yaml
         required:
         - format
         - query

--- a/openapi/paths/versions/_id/getContentVersion.yaml
+++ b/openapi/paths/versions/_id/getContentVersion.yaml
@@ -14,7 +14,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Versions.yaml
+              $ref: ../../../components/schemas/versions.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/versions/_id/save/saveContentVersion.yaml
+++ b/openapi/paths/versions/_id/save/saveContentVersion.yaml
@@ -12,7 +12,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../../components/schemas/Items.yaml
+              $ref: ../../../../components/schemas/items.yaml
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/versions/_id/updateContentVersion.yaml
+++ b/openapi/paths/versions/_id/updateContentVersion.yaml
@@ -10,7 +10,7 @@ requestBody:
     application/json:
       schema:
         anyOf:
-        - $ref: ../../../components/schemas/Versions.yaml
+        - $ref: ../../../components/schemas/versions.yaml
 responses:
   '200':
     description: Successful request
@@ -20,7 +20,7 @@ responses:
           type: object
           properties:
             data:
-              $ref: ../../../components/schemas/Versions.yaml
+              $ref: ../../../components/schemas/versions.yaml
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
   '404':

--- a/openapi/paths/versions/createContentVersions.yaml
+++ b/openapi/paths/versions/createContentVersions.yaml
@@ -18,7 +18,7 @@ requestBody:
           data:
             type: array
             items:
-              $ref: ../../components/schemas/Versions.yaml
+              $ref: ../../components/schemas/versions.yaml
 responses:
   '200':
     description: Successful request
@@ -30,7 +30,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Versions.yaml
+                $ref: ../../components/schemas/versions.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/versions/getContentVersions.yaml
+++ b/openapi/paths/versions/getContentVersions.yaml
@@ -20,7 +20,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Versions.yaml
+                $ref: ../../components/schemas/versions.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/openapi/paths/versions/updateContentVersions.yaml
+++ b/openapi/paths/versions/updateContentVersions.yaml
@@ -20,7 +20,7 @@ requestBody:
         properties:
           data:
             anyOf:
-            - $ref: ../../components/schemas/Versions.yaml
+            - $ref: ../../components/schemas/versions.yaml
           keys:
             type: array
             items:
@@ -36,7 +36,7 @@ responses:
             data:
               type: array
               items:
-                $ref: ../../components/schemas/Versions.yaml
+                $ref: ../../components/schemas/versions.yaml
             meta:
               $ref: ../../components/schemas/x-metadata.yaml
   '401':

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 	"scripts": {
 		"dev": "nodemon --watch './openapi/**/*.yaml' --exec 'redocly bundle ./openapi/index.yaml -o ./dist/index.yaml && pnpm scalar serve ./dist/oas.yaml -p 5001' --ext yaml",
 		"build": "redocly bundle ./openapi/index.yaml -o ./dist/oas.yaml && redocly bundle ./openapi/index.yaml -o ./dist/oas.json --ext json && jiti scripts/build-js.ts",
-		"lint": "redocly lint --max-problems=1000 ./dist/oas.yaml"
+		"lint": "redocly lint --max-problems=1000 ./dist/oas.yaml",
+		"fix-casing": "npx tsx scripts/fix-casing.ts"
 	},
 	"license": "MIT",
 	"devDependencies": {

--- a/scripts/fix-casing.ts
+++ b/scripts/fix-casing.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import glob from 'glob';
+
+const specRoot = './openapi';
+const yamlExt = ['.yaml', '.yml'];
+
+function getAllFiles(dir: string): string[] {
+  return glob.sync(`${dir}/**/*.{yaml,yml}`, { nodir: true });
+}
+
+function buildPathMap(files: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const file of files) {
+    map.set(path.resolve(file).toLowerCase(), path.resolve(file));
+  }
+  return map;
+}
+
+function fixRefsInFile(file: string, pathMap: Map<string, string>) {
+  let content = fs.readFileSync(file, 'utf8');
+  const dir = path.dirname(file);
+
+  const refRegex = /\$ref:\s*["']?([^\s"']+)["']?/g;
+  let changed = false;
+
+  const newContent = content.replace(refRegex, (match, refPath) => {
+    if (refPath.startsWith('#') || refPath.includes('#/')) return match; // local or component ref
+
+    // Normalize relative path — assume relative to current file
+    const assumedPath = path.resolve(dir, refPath);
+    const fixed = pathMap.get(assumedPath.toLowerCase());
+
+    if (fixed && fixed !== assumedPath) {
+      const relFixed = path.relative(dir, fixed).replace(/\\/g, '/');
+      changed = true;
+      return `$ref: ${relFixed}`;
+    }
+
+    return match;
+  });
+
+  if (changed) {
+    fs.writeFileSync(file, newContent, 'utf8');
+    console.log(`✔ Fixed refs in ${file}`);
+  }
+}
+
+const files = getAllFiles(specRoot);
+const pathMap = buildPathMap(files);
+files.forEach(file => fixRefsInFile(file, pathMap));


### PR DESCRIPTION
Closes #6 

- Changed references in various YAML files from uppercase to lowercase for consistency across the API specification.
- Updated paths for permissions, policies, presets, relations, revisions, roles, shares, translations, users, and versions.
- Added a script to fix casing issues in references automatically.