### PR TITLE
Fix body schema for generate user TFA

### DIFF
--- a/openapi/paths/users/me/tfa/generate/generateTwoFactorSecret.yaml
+++ b/openapi/paths/users/me/tfa/generate/generateTwoFactorSecret.yaml
@@ -5,7 +5,7 @@ requestBody:
   content:
     application/json:
       schema:
-        type: string
+        type: object
         required:
           - password
         properties:


### PR DESCRIPTION
Migrated from: https://github.com/directus/docs/pull/365

Currently in the docs it is showing that body must be `[string]` but it should be
```json
{
  "password": "d1r3ctu5"
}