### PR TITLE
docs: Add clarification that Oauth is not available via GQL and SDK endpoints. Fix #42

### DIFF
--- a/openapi/paths/auth/oauth/_provider/oauthProvider.yaml
+++ b/openapi/paths/auth/oauth/_provider/oauthProvider.yaml
@@ -35,3 +35,10 @@ responses:
 security: []
 tags:
 - Authentication
+x-codeSamples:
+  - label: Directus SDK
+    lang: JavaScript
+    source: Not available in Directus SDK/GraphQL
+  - label: GraphQL
+    lang: GraphQL
+    source: Not available in Directus SDK/GraphQL


### PR DESCRIPTION
Added details explaining that oath is not available in Directus SDK and GraphQL. Fixes #42 

This should also enable the REST endpoint to display.