### PR TITLE
feat: add `/access` to API reference

### DIFF
--- a/openapi/components/schemas/_index.yaml
+++ b/openapi/components/schemas/_index.yaml
@@ -1,5 +1,7 @@
 x-metadata:
   $ref: x-metadata.yaml
+Access:
+  $ref: access.yaml
 Activity:
   $ref: activity.yaml
 Collections:

--- a/openapi/components/schemas/access.yaml
+++ b/openapi/components/schemas/access.yaml
@@ -1,0 +1,36 @@
+type: object
+properties:
+  id:
+    description: Primary key of the access rule.
+    example: 8cbb43fe-4cdf-4991-8352-c461779cec02
+    type: string
+    format: uuid
+  role:
+    description: The role this access rule applies to. Nullable if the rule applies directly to a user. Many-to-one to roles.
+    example: 8b4474c0-288d-4bb8-b62e-8330646bb6aa
+    nullable: true
+    oneOf:
+      - type: string
+        format: uuid
+      - $ref: roles.yaml
+  user:
+    description: The user this access rule applies to. Nullable if the rule applies to a role. Many-to-one to users.
+    example: 0bc7b36a-9ba9-4ce0-83f0-0a526f354e07
+    nullable: true
+    oneOf:
+      - type: string
+        format: uuid
+      - $ref: users.yaml
+  policy:
+    description: The policy associated with this access rule. Many-to-one to policies.
+    example: 22640672-eef0-4ee9-ab04-591f3afb2886
+    oneOf:
+      - type: string
+        format: uuid
+      - $ref: policies.yaml
+  sort:
+    description: Sort order of this access rule.
+    example: 1
+    nullable: true
+    type: integer
+x-collection: directus_access

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -11,6 +11,12 @@ servers:
     description: Your current Directus project.
 
 paths:
+  "/access":
+    $ref: paths/access/index.yaml
+  "/access‎":
+    $ref: paths/access/singular/index.yaml
+  "/access/{id}":
+    $ref: paths/access/_id/index.yaml
   "/activity":
     $ref: paths/activity/index.yaml
   "/activity/{id}":
@@ -240,6 +246,9 @@ components:
     $ref: components/schemas/_index.yaml
 security: []
 tags:
+  - name: Access
+    description: Access rules define which policies are assigned to a role or user. They are the junction between policies and the roles or users they apply to.
+    x-collection: directus_access
   - name: Activity
     description: All events that happen within Directus are tracked and stored in the activities collection. This gives you full accountability over everything that happens.
     x-collection: directus_activity

--- a/openapi/paths/access/_id/deleteAccessRule.yaml
+++ b/openapi/paths/access/_id/deleteAccessRule.yaml
@@ -1,0 +1,24 @@
+summary: Delete an Access Rule
+description: Delete an existing access rule.
+operationId: deleteAccessRule
+responses:
+  '204':
+    description: The resource was deleted successfully.
+  '401':
+    $ref: ../../../components/responses.yaml#/UnauthorizedError
+  '404':
+    $ref: ../../../components/responses.yaml#/NotFoundError
+security: []
+tags:
+- Access
+parameters:
+- $ref: ../../../components/parameters.yaml#/UUId
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL

--- a/openapi/paths/access/_id/getAccessRule.yaml
+++ b/openapi/paths/access/_id/getAccessRule.yaml
@@ -1,0 +1,33 @@
+summary: Retrieve an Access Rule
+description: Retrieve a single access rule by unique identifier.
+operationId: getAccessRule
+parameters:
+- $ref: ../../../components/parameters.yaml#/UUId
+- $ref: ../../../components/parameters.yaml#/Fields
+- $ref: ../../../components/parameters.yaml#/Meta
+responses:
+  '200':
+    description: Successful request
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              $ref: ../../../components/schemas/access.yaml
+  '401':
+    $ref: ../../../components/responses.yaml#/UnauthorizedError
+  '404':
+    $ref: ../../../components/responses.yaml#/NotFoundError
+security: []
+tags:
+- Access
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL

--- a/openapi/paths/access/_id/index.yaml
+++ b/openapi/paths/access/_id/index.yaml
@@ -1,0 +1,6 @@
+get:
+  $ref: getAccessRule.yaml
+patch:
+  $ref: updateAccessRule.yaml
+delete:
+  $ref: deleteAccessRule.yaml

--- a/openapi/paths/access/_id/updateAccessRule.yaml
+++ b/openapi/paths/access/_id/updateAccessRule.yaml
@@ -1,0 +1,57 @@
+summary: Update an Access Rule
+description: Update an existing access rule.
+operationId: updateAccessRule
+parameters:
+- $ref: ../../../components/parameters.yaml#/UUId
+- $ref: ../../../components/parameters.yaml#/Fields
+- $ref: ../../../components/parameters.yaml#/Meta
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          role:
+            type: string
+            format: uuid
+            nullable: true
+            description: The role this access rule applies to.
+          user:
+            type: string
+            format: uuid
+            nullable: true
+            description: The user this access rule applies to.
+          policy:
+            type: string
+            format: uuid
+            description: The policy associated with this access rule.
+          sort:
+            type: integer
+            nullable: true
+            description: Sort order of this access rule.
+responses:
+  '200':
+    description: Successful request
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              $ref: ../../../components/schemas/access.yaml
+  '401':
+    $ref: ../../../components/responses.yaml#/UnauthorizedError
+  '404':
+    $ref: ../../../components/responses.yaml#/NotFoundError
+security: []
+tags:
+- Access
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL

--- a/openapi/paths/access/createAccessRules.yaml
+++ b/openapi/paths/access/createAccessRules.yaml
@@ -1,0 +1,51 @@
+summary: Create Multiple Access Rules
+description: Create multiple new access rules.
+operationId: createAccessRules
+parameters:
+- $ref: ../../components/parameters.yaml#/Fields
+- $ref: ../../components/parameters.yaml#/Limit
+- $ref: ../../components/parameters.yaml#/Meta
+- $ref: ../../components/parameters.yaml#/Offset
+- $ref: ../../components/parameters.yaml#/Sort
+- $ref: ../../components/parameters.yaml#/Filter
+- $ref: ../../components/parameters.yaml#/Search
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          data:
+            type: array
+            items:
+              $ref: ../../components/schemas/access.yaml
+responses:
+  '200':
+    description: Successful request
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: ../../components/schemas/access.yaml
+            meta:
+              $ref: ../../components/schemas/x-metadata.yaml
+  '401':
+    $ref: ../../components/responses.yaml#/UnauthorizedError
+  '404':
+    $ref: ../../components/responses.yaml#/NotFoundError
+security: []
+tags:
+- Access
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL

--- a/openapi/paths/access/deleteAccessRules.yaml
+++ b/openapi/paths/access/deleteAccessRules.yaml
@@ -1,0 +1,28 @@
+summary: Delete Multiple Access Rules
+description: Delete multiple existing access rules.
+operationId: deleteAccessRules
+requestBody:
+  description: An array of access rule primary keys.
+  content:
+    application/json:
+      schema:
+        type: array
+        items:
+          type: string
+responses:
+  '204':
+    description: The resource was deleted successfully.
+  '401':
+    $ref: ../../components/responses.yaml#/UnauthorizedError
+security: []
+tags:
+- Access
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL

--- a/openapi/paths/access/getAccessRules.yaml
+++ b/openapi/paths/access/getAccessRules.yaml
@@ -1,0 +1,42 @@
+summary: List Access Rules
+description: List all access rules that exist in Directus.
+operationId: getAccessRules
+parameters:
+- $ref: ../../components/parameters.yaml#/Fields
+- $ref: ../../components/parameters.yaml#/Limit
+- $ref: ../../components/parameters.yaml#/Offset
+- $ref: ../../components/parameters.yaml#/Meta
+- $ref: ../../components/parameters.yaml#/Sort
+- $ref: ../../components/parameters.yaml#/Filter
+- $ref: ../../components/parameters.yaml#/Search
+- $ref: ../../components/parameters.yaml#/Page
+responses:
+  '200':
+    description: Successful request
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: ../../components/schemas/access.yaml
+            meta:
+              $ref: ../../components/schemas/x-metadata.yaml
+  '401':
+    $ref: ../../components/responses.yaml#/UnauthorizedError
+  '404':
+    $ref: ../../components/responses.yaml#/NotFoundError
+security: []
+tags:
+- Access
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL

--- a/openapi/paths/access/index.yaml
+++ b/openapi/paths/access/index.yaml
@@ -1,0 +1,8 @@
+get:
+  $ref: getAccessRules.yaml
+post:
+  $ref: createAccessRules.yaml
+patch:
+  $ref: updateAccessRules.yaml
+delete:
+  $ref: deleteAccessRules.yaml

--- a/openapi/paths/access/singular/createAccessRule.yaml
+++ b/openapi/paths/access/singular/createAccessRule.yaml
@@ -1,0 +1,55 @@
+summary: Create an Access Rule
+description: Create a new access rule.
+operationId: createAccessRule
+parameters:
+- $ref: ../../../components/parameters.yaml#/Fields
+- $ref: ../../../components/parameters.yaml#/Meta
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          role:
+            type: string
+            format: uuid
+            nullable: true
+            description: The role this access rule applies to.
+          user:
+            type: string
+            format: uuid
+            nullable: true
+            description: The user this access rule applies to.
+          policy:
+            type: string
+            format: uuid
+            description: The policy associated with this access rule.
+          sort:
+            type: integer
+            nullable: true
+            description: Sort order of this access rule.
+responses:
+  '200':
+    description: Successful request
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              $ref: ../../../components/schemas/access.yaml
+  '401':
+    $ref: ../../../components/responses.yaml#/UnauthorizedError
+  '404':
+    $ref: ../../../components/responses.yaml#/NotFoundError
+tags:
+- Access
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL

--- a/openapi/paths/access/singular/index.yaml
+++ b/openapi/paths/access/singular/index.yaml
@@ -1,0 +1,2 @@
+post:
+  $ref: createAccessRule.yaml

--- a/openapi/paths/access/updateAccessRules.yaml
+++ b/openapi/paths/access/updateAccessRules.yaml
@@ -1,0 +1,73 @@
+summary: Update Multiple Access Rules
+description: Update multiple access rules at the same time.
+security: []
+tags:
+- Access
+operationId: updateAccessRules
+parameters:
+- $ref: ../../components/parameters.yaml#/Fields
+- $ref: ../../components/parameters.yaml#/Limit
+- $ref: ../../components/parameters.yaml#/Meta
+- $ref: ../../components/parameters.yaml#/Offset
+- $ref: ../../components/parameters.yaml#/Sort
+- $ref: ../../components/parameters.yaml#/Filter
+- $ref: ../../components/parameters.yaml#/Search
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+          - keys
+          - data
+        properties:
+          keys:
+            type: array
+            items:
+              type: string
+          data:
+            type: object
+            properties:
+              role:
+                type: string
+                format: uuid
+                nullable: true
+                description: The role this access rule applies to.
+              user:
+                type: string
+                format: uuid
+                nullable: true
+                description: The user this access rule applies to.
+              policy:
+                type: string
+                format: uuid
+                description: The policy associated with this access rule.
+              sort:
+                type: integer
+                nullable: true
+                description: Sort order of this access rule.
+responses:
+  '200':
+    description: Successful request
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: ../../components/schemas/access.yaml
+            meta:
+              $ref: ../../components/schemas/x-metadata.yaml
+  '401':
+    $ref: ../../components/responses.yaml#/UnauthorizedError
+x-codeSamples:
+- label: Directus SDK
+  lang: JavaScript
+  source: |
+    // Not supported in Directus SDK
+- label: GraphQL
+  lang: GraphQL
+  source: |
+    // Not supported in GraphQL


### PR DESCRIPTION
Adds Schema reference as well as the applicable CRUD options.

NOTE: I opted to clarify in filenames that they reference accessRules rather than trying to figure out how to pluralize accesses in a way that doesn't hurt my brain or stress my ability to verbalize it.

Fixes #40

I did not see any [SDK commands](url) for `access` so I noted that the SDK is not supported.
I don't know GraphQL well enough to see if it's not there, but I couldn't find it anywhere so I also noted it as not supported.

---

I wanted to call attention to the following items as possible issues unrelated to this commit but discovered in the process

- [x] ~~scripts in package.json `build` and `dev` use Scalar presentation that does not match formatting/styling at directus.io/docs/api~~ See #64 
- [x] After Research, I found an explanation/clarity I was looking for... for posterity: Scalar output has `%E2%80%8E` appended to `POST` requests for create commands when using `HTTP HTTP/1.1`
  - create access rule & (previous example) create a policy <img width="971" height="295" alt="Screenshot 2026-04-23 at 09 12 37" src="https://github.com/user-attachments/assets/0427c459-d3cd-447f-9f6e-9afc8e7ff0cd" /><img width="987" height="239" alt="Screenshot 2026-04-23 at 09 12 19" src="https://github.com/user-attachments/assets/5be0a81f-b148-4b48-8b3d-1237bd7088a7" />
      - Note that this is not visible in the production deployment: https://directus.io/docs/api/policies#create-a-policy
  - It's difficult (impossible)? to detect in git diff <img width="568" height="302" alt="Screenshot 2026-04-23 at 09 27 37" src="https://github.com/user-attachments/assets/eabe3f5d-1319-49e3-b7f2-27df8a6ac284" /> Troubleshooting in another editor I was able to see the hidden characters: <img width="465" height="158" alt="Screenshot 2026-04-23 at 09 59 45" src="https://github.com/user-attachments/assets/9ce0d719-9536-46a6-8439-444f1ba982c5" />


Maybe the fix is to have a contribution guideline that explains it? I'm not the only one who was befuddled (see #46)

