### PR TITLE
chore: update readme (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Directus' OpenAPI Specification
 
-This repo contains the OpenAPI specifications for Directus' API.
+This repo contains the OpenAPI specifications for [Directus' API](https://www.directus.io/docs/api).
 
 The static spec in this repo contains all the system endpoints and a definition for a generic `/items/{collection}` endpoint.
+
+> [!IMPORTANT]
+> If you are experiencing issues with the OpenAPI Specification on your cloud or self hosted instance (https://your-instance.directus.cloud/server/specs/oas), report the issue [Directus/Directus](https://github.com/directus/directus).
 
 ## Usage
 
@@ -23,6 +26,21 @@ Key that maps a system endpoint to its corresponding system collection.
 ### `x-codeSamples`
 
 Examples of how to use the equivalent of the documented REST endpoint in the JS SDK and/or GraphQL endpoint.
+
+## Adding an Endpoint
+
+Endpoints that allow for requests that createSingular and createMultiple on the same path have an invisible special character appended to their record at `openapi/index.yaml`. Copy the code block below and change `<endpoint>` to the path of your endpoint.
+
+```yaml
+  "/<endpoint>":
+    $ref: paths/<endpoint>/index.yaml
+  "/<endpoint>‎":
+    $ref: paths/<endpoint>/singular/index.yaml
+  "/<endpoint>/{id}":
+    $ref: paths/<endpoint>/_id/index.yaml
+```
+
+Take extra care not to delete the special character by using Find and Replace in your IDE.
 
 ## Deploying Releases
 


### PR DESCRIPTION
Highlighted that this repository supports directus.io/docs/api and that issues with issues with
https://your-instance.directus.cloud/server/specs/oas should be pointed to monorepo.

Added a yankable code block with the special character.

---

Fixes #64