### PR TITLE
fix(spec): correct response shapes and query params per core review

### DIFF
--- a/openapi/components/parameters.yaml
+++ b/openapi/components/parameters.yaml
@@ -216,7 +216,7 @@ Deep:
               type: integer
             _search:
               type: string
-            _group:
+            _groupBy:
               type: array
               items:
                 type: string
@@ -246,7 +246,7 @@ Alias:
 Group:
   description: >-
     Grouping allows for running the aggregation functions based on a shared value. Accepts an array of field names.
-  name: group
+  name: groupBy
   in: query
   required: false
   explode: false

--- a/openapi/paths/ai/files/aiFileUpload.yaml
+++ b/openapi/paths/ai/files/aiFileUpload.yaml
@@ -32,10 +32,34 @@ responses:
       application/json:
         schema:
           type: object
+          required:
+            - provider
+            - fileId
+            - filename
+            - mimeType
+            - sizeBytes
+            - expiresAt
           properties:
-            data:
-              type: object
-              description: Provider-specific file reference returned after upload.
+            provider:
+              type: string
+              enum:
+                - openai
+                - anthropic
+                - google
+            fileId:
+              type: string
+              description: Provider-issued identifier for the uploaded file.
+            filename:
+              type: string
+            mimeType:
+              type: string
+            sizeBytes:
+              type: integer
+            expiresAt:
+              type: string
+              format: date-time
+              nullable: true
+              description: When the provider will expire the file. Null if it does not expire.
   '403':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 security: []

--- a/openapi/paths/auth/oauth/oauth.yaml
+++ b/openapi/paths/auth/oauth/oauth.yaml
@@ -4,6 +4,13 @@ tags:
 - Authentication
 operationId: oauth
 description: List all the configured auth providers.
+parameters:
+- name: sessionOnly
+  in: query
+  description: When set, returns only providers compatible with session mode.
+  required: false
+  schema:
+    type: boolean
 responses:
   '200':
     description: Successful request
@@ -12,23 +19,26 @@ responses:
         schema:
           type: object
           properties:
-            public:
-              type: boolean
             data:
-              type: object
-              properties:
-                name:
-                  type: string
-                  example: google
-                label:
-                  type: string
-                  example: Google
-                driver:
-                  type: string
-                  example: openid
-                icon:
-                  type: string
-                  example: google
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    example: google
+                  label:
+                    type: string
+                    example: Google
+                  driver:
+                    type: string
+                    example: openid
+                  icon:
+                    type: string
+                    example: google
+            disableDefault:
+              type: boolean
+              description: Whether the default email/password login is disabled.
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 x-codeSamples:

--- a/openapi/paths/extensions/registry/install/installRegistryExtension.yaml
+++ b/openapi/paths/extensions/registry/install/installRegistryExtension.yaml
@@ -21,7 +21,7 @@ requestBody:
             type: string
             example: 1.2.3
 responses:
-  '200':
+  '204':
     description: Extension installed successfully.
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/extensions/registry/listRegistryExtensions.yaml
+++ b/openapi/paths/extensions/registry/listRegistryExtensions.yaml
@@ -14,12 +14,74 @@ responses:
       application/json:
         schema:
           type: object
+          required:
+            - meta
+            - data
           properties:
+            meta:
+              type: object
+              required:
+                - filter_count
+              properties:
+                filter_count:
+                  type: integer
+                  description: Total number of registry extensions matching the query.
             data:
               type: array
               items:
                 type: object
-                description: Registry extension listing.
+                required:
+                  - id
+                  - name
+                  - description
+                  - total_downloads
+                  - verified
+                  - type
+                  - last_updated
+                  - host_version
+                  - sandbox
+                  - license
+                  - publisher
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  description:
+                    type: string
+                    nullable: true
+                  total_downloads:
+                    type: integer
+                  verified:
+                    type: boolean
+                  type:
+                    type: string
+                    description: Extension type.
+                  last_updated:
+                    type: string
+                    format: date-time
+                  host_version:
+                    type: string
+                    description: Directus version range the extension supports.
+                  sandbox:
+                    type: boolean
+                  license:
+                    type: string
+                    nullable: true
+                  publisher:
+                    type: object
+                    required:
+                      - username
+                      - verified
+                      - github_name
+                    properties:
+                      username:
+                        type: string
+                      verified:
+                        type: boolean
+                      github_name:
+                        type: string
+                        nullable: true
   '401':
     $ref: ../../../components/responses.yaml#/UnauthorizedError
 security: []

--- a/openapi/paths/extensions/registry/reinstall/reinstallRegistryExtension.yaml
+++ b/openapi/paths/extensions/registry/reinstall/reinstallRegistryExtension.yaml
@@ -16,7 +16,7 @@ requestBody:
             format: uuid
             example: 8cbb43fe-4cdf-4991-8352-c461779cec02
 responses:
-  '200':
+  '204':
     description: Extension reinstalled successfully.
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError

--- a/openapi/paths/utils/revert/_revision/revert.yaml
+++ b/openapi/paths/utils/revert/_revision/revert.yaml
@@ -9,8 +9,8 @@ parameters:
   schema:
     type: string
 responses:
-  '200':
-    description: Successful request
+  '204':
+    description: Revision reverted successfully.
   '401':
     $ref: ../../../../components/responses.yaml#/UnauthorizedError
   '404':


### PR DESCRIPTION
Addresses review findings on #66 by aligning the spec with what Directus core actually returns and parses. Each fix verified against `directus/directus`.

## Summary

- **`/auth`**: `data` is `ReadProviderOutput[]`, not a single object. Response also includes `disableDefault` (not `public`). Added `sessionOnly` query param. (`api/src/controllers/auth.ts:258`, `api/src/utils/get-auth-providers.ts:11`)
- **`group` query params**: renamed `group` → `groupBy` and `_group` → `_groupBy`. `sanitizeQuery` only parses `groupBy`/`_groupBy`. (`api/src/utils/sanitize-query.ts:48`)
- **`/ai/files`**: handler calls `res.json(result)` where `result` is `ProviderFileRef`. Removed `{ data: ... }` wrapper, typed full shape (`provider`, `fileId`, `filename`, `mimeType`, `sizeBytes`, `expiresAt`). (`api/src/ai/files/controllers/upload.ts:132`, `packages/ai/src/types.ts:81`)
- **No-content mutations**: registry install, reinstall, and utils revert never set `res.locals.payload`; `respond` middleware emits 204. Changed documented status from 200 to 204. (`api/src/middleware/respond.ts:124`)
- **Registry list response**: added `meta.filter_count` and the full extension item schema (`id`, `name`, `description`, `total_downloads`, `verified`, `type`, `last_updated`, `host_version`, `sandbox`, `license`, `publisher{...}`). (`packages/extensions-registry/src/modules/list/schemas/registry-list-response.ts`)

## Test plan

- [x] \`pnpm build\` — bundles cleanly
- [x] \`pnpm lint\` — passes (only the pre-existing \`/deployments/webhooks/{provider}\` ambiguity warning remains)
- [ ] Spot-check rendered Redoc output for /auth, /ai/files, /extensions/registry