### PR TITLE
Release 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@directus/openapi",
 	"private": false,
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "OpenAPI Specification of the Directus API",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/openapi.git"


### PR DESCRIPTION
In trying to troubleshoot directus/openapi#72 I was able to determine that the directus/docs repository relies on the NPM release of this package.

I also updated package.json homepage entry domain from .io to .com (related directus/docs#707)


- Fixes directus/openapi#72